### PR TITLE
UI improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,12 +4,12 @@
         <title>Layered Zoning Map</title>
 
         <script src='./js/main.js'></script>    
--   
--        <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" />    
--        <script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>    
--        <script src="https://rawgit.com/heigeo/leaflet.wms/leaflet073/leaflet.wms.js"></script>    
--        <script type="text/javascript" src="http://maps.stamen.com/js/tile.stamen.js?v1.3.0"></script>   
--        <script src="https://cdn.rawgit.com/MetropolitanTransportationCommission/zoning/gh-pages/layer/tile/Bing.js"></script>
+
+        <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" />    
+        <script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>    
+        <script src="https://rawgit.com/heigeo/leaflet.wms/leaflet073/leaflet.wms.js"></script>    
+        <script type="text/javascript" src="http://maps.stamen.com/js/tile.stamen.js?v1.3.0"></script>   
+        <script src="https://cdn.rawgit.com/MetropolitanTransportationCommission/zoning/gh-pages/layer/tile/Bing.js"></script>
 
         <style>
         body {

--- a/js/main.js
+++ b/js/main.js
@@ -34,6 +34,7 @@ document.getElementById('maxdua_light').onclick = function () {
     var enable = this.className !== 'active';
     maxdua.setOpacity(enable ? 0.3 : 0);
     this.className = enable ? 'active' : '';
+    document.getElementById('maxdua_heavy').className = '';
     return false;
 };
 
@@ -41,6 +42,7 @@ document.getElementById('maxdua_heavy').onclick = function () {
     var enable = this.className !== 'active';
     maxdua.setOpacity(enable ? 0.7 : 0);
     this.className = enable ? 'active' : '';
+    document.getElementById('maxdua_light').className = '';
     return false;
 };
 
@@ -48,6 +50,7 @@ document.getElementById('maxfar_light').onclick = function () {
     var enable = this.className !== 'active';
     maxfar.setOpacity(enable ? 0.3 : 0);
     this.className = enable ? 'active' : '';
+    document.getElementById('maxfar_heavy').className = '';
     return false;
 };
 
@@ -55,6 +58,7 @@ document.getElementById('maxfar_heavy').onclick = function () {
     var enable = this.className !== 'active';
     maxfar.setOpacity(enable ? 0.7 : 0);
     this.className = enable ? 'active' : '';
+    document.getElementById('maxfar_light').className = '';
     return false;
 };
 


### PR DESCRIPTION
I thought the toggling of the behavior of the office/residential buttons could be improved. 

Currently, when you change the transparency of a layer, the prior transparency button is still active. 

In this PR, when you turn increase, or decrease the transparency of a layer, the corresponding layer button deactivates. Also, dashes do not show up at the top of the page.

To make it easier, I've attached this gif showing how the buttons now work. 

![gif of it as a demo](https://media.giphy.com/media/81KhaMi8H1Rcs/giphy.gif)

You can try it out on my branch: http://eunoia.github.io/zoning/
